### PR TITLE
Change PWP::Encoding to PWP::SingleEncoding

### DIFF
--- a/weaver.ini
+++ b/weaver.ini
@@ -4,7 +4,7 @@
 
 ; Encode as UTF-8.
 ; TODO - Maybe ASCII is better for copy and paste?
-[-Encoding]
+[-SingleEncoding]
 encoding = UTF-8
 
 [-StopWords]


### PR DESCRIPTION
Hi,

`Pod::Weaver` has `SingleEncoding` plugin now (starting from 4.000). This makes `Pod::Weaver::Plugin::Encoding` an extra dependency that could be thrown away.

See [Rik's post](http://rjbs.manxome.org/rubric/entry/2021) and also check out my quest for details:

> http://questhub.io/realm/perl/quest/5277f3cc9f567ad56f0000e7

Cheers,
Sergey
