### PR TITLE
Fixes to make `dzil test` pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Reflex-*.*
+.build/

--- a/lib/MooseX/Role/Reactive.pm
+++ b/lib/MooseX/Role/Reactive.pm
@@ -1,4 +1,4 @@
-pacakage MooseX::Role::Reactive;
+package MooseX::Role::Reactive;
 
 use Moose::Role;
 

--- a/lib/Reflex.pm
+++ b/lib/Reflex.pm
@@ -365,9 +365,9 @@ lengthy and sometimes irrelevant design discussion for oh so long.
 
 L<Moose>, L<POE>, the Reflex and Reflexive namespaces on CPAN.
 
-Ohlo - https://www.ohloh.net/p/reflex-perl
+Ohlo - L<https://www.ohloh.net/p/reflex-perl>
 
-CIA - http://cia.vc/stats/project/reflex
+CIA - L<http://cia.vc/stats/project/reflex>
 
 =head1 BUGS
 

--- a/lib/Reflex/Callback.pm
+++ b/lib/Reflex/Callback.pm
@@ -16,6 +16,8 @@ __PACKAGE__->meta->make_immutable;
 
 __END__
 
+=for Pod::Coverage deliver make_emitter make_error_handler make_null_handler make_terminal_emitter
+
 =head1 NAME
 
 Reflex::Callback - Generic callback adapters to simplify calling back

--- a/lib/Reflex/Callback/Promise.pm
+++ b/lib/Reflex/Callback/Promise.pm
@@ -56,6 +56,8 @@ __PACKAGE__->meta->make_immutable;
 
 __END__
 
+=for Pod::Coverage merge_into
+
 =head1 NAME
 
 Reflex::Callback::Promise - Non-callback, inline Promise adapter

--- a/lib/Reflex/Callbacks.pm
+++ b/lib/Reflex/Callbacks.pm
@@ -282,6 +282,8 @@ __PACKAGE__->meta->make_immutable;
 
 __END__
 
+=for Pod::Coverage deliver make_emitter make_error_handler make_null_handler make_terminal_emitter
+
 =head1 NAME
 
 Reflex::Callbacks - Convenience functions for creating and using callbacks

--- a/lib/Reflex/Client.pm
+++ b/lib/Reflex/Client.pm
@@ -89,6 +89,8 @@ __PACKAGE__->meta->make_immutable;
 
 __END__
 
+=for Pod::Coverage on_connection_closed on_connection_data on_connection_failure stop
+
 =head1 NAME
 
 Reflex::Client - A non-blocking socket client.

--- a/lib/Reflex/Collection.pm
+++ b/lib/Reflex/Collection.pm
@@ -95,6 +95,8 @@ __PACKAGE__->meta->make_immutable;
 
 __END__
 
+=for Pod::Coverage cb_forget
+
 =head1 NAME
 
 Reflex::Collection - Autmatically manage a collection of collectible objects

--- a/lib/Reflex/Decoder/Line.pm
+++ b/lib/Reflex/Decoder/Line.pm
@@ -41,3 +41,7 @@ sub shift {
 __PACKAGE__->meta->make_immutable;
 
 1;
+
+__END__
+
+=for Pod::Coverage shift

--- a/lib/Reflex/Eg.pm
+++ b/lib/Reflex/Eg.pm
@@ -1,4 +1,5 @@
 package Reflex::Eg;
+use Moose;
 
 __PACKAGE__->meta->make_immutable;
 
@@ -6,13 +7,23 @@ __PACKAGE__->meta->make_immutable;
 
 =pod
 
-=abstract Index of Reflex Examples
+=head1 NAME
+
+Reflex::Eg - Reflex examples namespace
 
 =head1 EXAMPLES
 
+Index of examples using this namespace:
+
 =over 4
 
-=index ^Reflex::Eg::
+=item *
+
+L<Reflex::Eg::Inheritance::Moose>
+
+=item *
+
+L<Reflex::Eg::Inheritance::Plain>
 
 =back
 

--- a/lib/Reflex/Eg/Inheritance/Moose.pm
+++ b/lib/Reflex/Eg/Inheritance/Moose.pm
@@ -16,11 +16,11 @@ __END__
 
 =pod
 
-=abstract Inheriting a Reflex timer using Moose.
+=head1 NAME
+
+Reflex::Eg::Inheritance::Moose - Inheriting a Reflex timer using Moose.
 
 =head1 SYNOPSIS
-
-=example Reflex::Eg::Inheritance::Moose
 
 Usage:
 

--- a/lib/Reflex/Eg/Inheritance/Plain.pm
+++ b/lib/Reflex/Eg/Inheritance/Plain.pm
@@ -17,11 +17,11 @@ __END__
 
 =pod
 
-=abstract Inheriting a Reflex timer with plain Perl.
+=head1 NAME
+
+Reflex::Eg::Inheritance::Plain - Inheriting a Reflex timer with plain Perl.
 
 =head1 SYNOPSIS
-
-=example Reflex::Eg::Inheritance::Plain
 
 Usage:
 
@@ -32,7 +32,22 @@ Usage:
 This module is nearly identical to Reflex::Eg::Inheritance::Moose.
 It only differs in the mechanism of subclassing Reflex::Timeout.
 
-=include Reflex::Eg::Inheritance::Moose DESCRIPTION
+=for comment Reflex::Eg::Inheritance::Moose DESCRIPTION begins
+
+Reflex::Timeout objects normally go dormant after the first time they
+call on_done().
+
+[% doc.module %] implements a simple periodic timer by subclassing and
+overriding Reflex::Timeout's on_done() callback.  The act of finishing
+the timeout causes itself to be reset.
+
+Since this is an example, the subclass also prints a message so it's
+apparent it works.
+
+This is a relatively silly exercise.
+Reflex::Interval already implements a periodic interval timer.
+
+=for comment Reflex::Eg::Inheritance::Moose DESCRIPTION ends
 
 =cut
 

--- a/lib/Reflex/Encoder/Line.pm
+++ b/lib/Reflex/Encoder/Line.pm
@@ -47,3 +47,7 @@ sub shift {
 __PACKAGE__->meta->make_immutable;
 
 1;
+
+__END__
+
+=for Pod::Coverage shift push_data

--- a/lib/Reflex/Event.pm
+++ b/lib/Reflex/Event.pm
@@ -146,3 +146,7 @@ __PACKAGE__->make_event_cloner;
 __PACKAGE__->meta->make_immutable;
 
 1;
+
+__END__
+
+=for Pod::Coverage make_event_cloner push_emitter

--- a/lib/Reflex/POE/Event.pm
+++ b/lib/Reflex/POE/Event.pm
@@ -56,6 +56,8 @@ __PACKAGE__->meta->make_immutable;
 
 __END__
 
+=for Pod::Coverage BUILD deliver
+
 =head1 NAME
 
 Reflex::POE::Event - Communicate with POE components expecting events.

--- a/lib/Reflex/POE/Session.pm
+++ b/lib/Reflex/POE/Session.pm
@@ -51,6 +51,8 @@ __PACKAGE__->meta->make_immutable;
 
 __END__
 
+=for Pod::Coverage BUILD DEMOLISH deliver
+
 =head1 NAME
 
 Reflex::POE::Session - Watch events from a POE::Session object.

--- a/lib/Reflex/POE/Wheel.pm
+++ b/lib/Reflex/POE/Wheel.pm
@@ -101,6 +101,8 @@ __PACKAGE__->meta->make_immutable;
 
 __END__
 
+=for Pod::Coverage BUILD DEMOLISH create_wheel deliver
+
 =head1 NAME
 
 Reflex::POE::Wheel - Base class for POE::Wheel wrappers.

--- a/lib/Reflex/POE/Wheel/Run.pm
+++ b/lib/Reflex/POE/Wheel/Run.pm
@@ -105,6 +105,8 @@ __PACKAGE__->meta->make_immutable;
 
 __END__
 
+=for Pod::Coverage BUILD events_to_indices index_to_event on_sigchld_exit
+
 =head1 NAME
 
 Reflex::POE::Wheel::Run - Represent POE::Wheel::Run as a Reflex class.

--- a/lib/Reflex/Role.pm
+++ b/lib/Reflex/Role.pm
@@ -125,6 +125,8 @@ BEGIN { *callback_parameter = *method_parameter; }
 
 __END__
 
+=for Pod::Coverage init_meta
+
 =head1 NAME
 
 Reflex::Role - define a Reflex paramaterized role

--- a/lib/Reflex/Role/Collectible.pm
+++ b/lib/Reflex/Role/Collectible.pm
@@ -22,6 +22,8 @@ sub result {
 
 __END__
 
+=for Pod::Coverage result stopped
+
 =head1 NAME
 
 Reflex::Role::Collectible - add manageability by Reflex::Collection

--- a/lib/Reflex/Role/Connecting.pm
+++ b/lib/Reflex/Role/Connecting.pm
@@ -121,6 +121,8 @@ role {
 
 __END__
 
+=for Pod::Coverage BUILD EINPROGRESS EWOULDBLOCK SOL_SOCKET SO_ERROR
+
 =head1 NAME
 
 Reflex::Role::Connecting - add non-blocking client connecting to a class

--- a/lib/Reflex/Role/Interval.pm
+++ b/lib/Reflex/Role/Interval.pm
@@ -126,6 +126,8 @@ role {
 
 __END__
 
+=for Pod::Coverage BUILD
+
 =head1 NAME
 
 Reflex::Role::Interval - set a periodic, recurring timer

--- a/lib/Reflex/Role/PidCatcher.pm
+++ b/lib/Reflex/Role/PidCatcher.pm
@@ -148,6 +148,8 @@ role {
 
 __END__
 
+=for Pod::Coverage BUILD DEMOLISH deliver
+
 =head1 NAME
 
 Reflex::Role::PidCatcher - add async process reaping behavior to a class

--- a/lib/Reflex/Role/Reactive.pm
+++ b/lib/Reflex/Role/Reactive.pm
@@ -677,6 +677,8 @@ sub next {
 
 __END__
 
+=for Pod::Coverage BUILD DEMOLISH deliver get_id re_emit
+
 =head1 NAME
 
 Reflex::Role::Reactive - Make an object reactive (aka, event driven).

--- a/lib/Reflex/Role/Readable.pm
+++ b/lib/Reflex/Role/Readable.pm
@@ -89,6 +89,8 @@ role {
 
 __END__
 
+=for Pod::Coverage BUILD DEMOLISH
+
 =head1 NAME
 
 Reflex::Role::Readable - add readable-watching behavior to a class

--- a/lib/Reflex/Role/SigCatcher.pm
+++ b/lib/Reflex/Role/SigCatcher.pm
@@ -153,6 +153,8 @@ role {
 
 __END__
 
+=for Pod::Coverage BUILD DEMOLISH deliver
+
 =head1 NAME
 
 Reflex::Role::SigCatcher - add signal catching behavior to a class

--- a/lib/Reflex/Role/Timeout.pm
+++ b/lib/Reflex/Role/Timeout.pm
@@ -95,6 +95,8 @@ role {
 
 __END__
 
+=for Pod::Coverage BUILD
+
 =head1 NAME
 
 Reflex::Role::Timeout - set a wakeup callback for a relative delay

--- a/lib/Reflex/Role/Wakeup.pm
+++ b/lib/Reflex/Role/Wakeup.pm
@@ -90,6 +90,8 @@ role {
 
 __END__
 
+=for Pod::Coverage BUILD
+
 =head1 NAME
 
 Reflex::Role::Wakeup - set a wakeup callback for a particular UNIX time

--- a/lib/Reflex/Role/Writable.pm
+++ b/lib/Reflex/Role/Writable.pm
@@ -86,6 +86,8 @@ role {
 
 __END__
 
+=for Pod::Coverage BUILD DEMOLISH
+
 =head1 NAME
 
 Reflex::Role::Writable - add writable-watching behavior to a class

--- a/lib/Reflex/Trait/EmitsOnChange.pm
+++ b/lib/Reflex/Trait/EmitsOnChange.pm
@@ -101,6 +101,8 @@ sub register_implementation { 'Reflex::Trait::EmitsOnChange' }
 
 __END__
 
+=for Pod::Coverage emits
+
 =head1 NAME
 
 Reflex::Trait::EmitsOnChange - Emit an event when an attribute's value changes.

--- a/lib/Reflex/Trait/Observed.pm
+++ b/lib/Reflex/Trait/Observed.pm
@@ -21,6 +21,8 @@ sub register_implementation { 'Reflex::Trait::Observed' }
 
 __END__
 
+=for Pod::Coverage observes
+
 =head1 NAME
 
 Reflex::Trait::Observed - Automaticall watch Reflex objects.

--- a/lib/Reflex/Trait/Watched.pm
+++ b/lib/Reflex/Trait/Watched.pm
@@ -127,6 +127,8 @@ sub register_implementation { 'Reflex::Trait::Watched' }
 
 __END__
 
+=for Pod::Coverage watches
+
 =head1 NAME
 
 Reflex::Trait::Watched - Automatically watch Reflex objects.

--- a/weaver.ini
+++ b/weaver.ini
@@ -55,7 +55,7 @@ command = export
 email = poe-subscribe@perl.org
 perldoc = 1
 websites = all
-repository_link = both
+repository_link = url
 bugs = rt
 irc = irc.perl.org, #reflex
 


### PR DESCRIPTION
Together, these commits make `dzil test` pass on my (OS X Yosemite, Perl 5.20) system:
- Minimal fixes to address errors in the `Pod::Coverage` and `Pod::Syntax` author tests.
- Fix obvious typo in `MooseX::Role::Reactive`.
- Workaround for mysterious fatal testing error: "Expected to find 'web' repository link but it is missing in the metadata".

I also added the `.build` directory to `.gitignore`.
